### PR TITLE
[174]  Modify Freak model fields

### DIFF
--- a/app/graphql/types/freak_type.rb
+++ b/app/graphql/types/freak_type.rb
@@ -3,7 +3,7 @@
 module Types
   class FreakType < Types::BaseObject
     field :id, GraphQL::Types::ID, null: false
-    field :name, String, null: false, deprecation_reason: 'Replaced by first_name and last_name'
+    field :name, String, null: false, deprecation_reason: 'Replaced by firstName and lastName'
     field :first_name, String, null: false
     field :last_name, String, null: false
     field :description, String, null: false

--- a/app/models/freak.rb
+++ b/app/models/freak.rb
@@ -6,6 +6,10 @@ class Freak < ApplicationRecord
   validates :description, presence: true
   validates :email, presence: true
 
+  def name
+    "#{first_name} #{last_name}"
+  end
+
   def photo
     {
       id: '1',

--- a/spec/controllers/graphql/queries/freaks_spec.rb
+++ b/spec/controllers/graphql/queries/freaks_spec.rb
@@ -30,4 +30,12 @@ module Graphql
       it { is_expected.to match_response_for(query: :freaks, sample: :freaks_pagination) }
     end
   end
+
+  RSpec.describe Freak, type: :model do
+    describe '#name' do
+      subject(:name) { described_class.create(first_name: 'John', last_name: 'Doe').name }
+
+      it { is_expected.to eq 'John Doe' }
+    end
+  end
 end

--- a/spec/fixtures/requests/queries/freaks.graphql
+++ b/spec/fixtures/requests/queries/freaks.graphql
@@ -8,6 +8,7 @@ query Freaks($last: Int, $before: String) {
         }
         edges {
             node {
+                name
                 firstName
                 lastName
                 description

--- a/spec/fixtures/responses/queries/freaks/freaks.json
+++ b/spec/fixtures/responses/queries/freaks/freaks.json
@@ -12,6 +12,7 @@
         "edges": [
           {
             "node": {
+              "name": "Ion doe",
               "firstName": "Ion",
               "lastName": "doe",
               "description": "a simple freak",
@@ -90,6 +91,7 @@
           },
           {
             "node": {
+              "name": "Gheorghe doe",
               "firstName": "Gheorghe",
               "lastName": "doe",
               "description": "a simple freak",

--- a/spec/fixtures/responses/queries/freaks/freaks_pagination.json
+++ b/spec/fixtures/responses/queries/freaks/freaks_pagination.json
@@ -12,6 +12,7 @@
         "edges": [
           {
             "node": {
+              "name": "Ion doe",
               "firstName": "Ion",
               "lastName": "doe",
               "description": "a simple freak",


### PR DESCRIPTION
## Description
In Freak model, field `name` was replaced by `first_name` and `last_name`.
In this PR was added a method 'name' which return a string from `first_name` and `last_name` field's concatenation, so there shouldn't be any errors in GraphQl queries after updating the freak model with latest changes

## Related
<!-- Edit the ticket below to match the correct one; you can specify here other related items, such as PRs -->
[[174] Update Freak model](https://trello.com/c/SHrtww0J/174-update-freak-model)

## Steps to Test or Reproduce

1. Go to Insomnia and create a Freak. Use this GraphQl mutation:
```GraphQl
mutation {
	freakCreate(firstName: "john", lastName: "doe", description: "ceva", email: "freak@gmail.com") {
    firstName
		lastName
		description
		email
	}
}
```
2. Query freaks to see that the new freak was created:
```GraphQl
query Freaks($last: Int, $before: String) {
  freaks(last: $last, before: $before) {
    edges {
      node {
        name
        firstName
        lastName
        description
        email
      }
    }
  }
}
```
You should get a list of freaks with their _name_, _firstName_, _lastName_, _description_ and _email_. Also, for _name_ field you should see this message: _"The field freak.name is deprecated. Replaced by firstName and lastName"_.

