### PR TITLE
[] Rename Speciality type to Specialty

### DIFF
--- a/app/graphql/resolvers/mock_data.json
+++ b/app/graphql/resolvers/mock_data.json
@@ -60,7 +60,7 @@
                 "id": "1",
                 "name": "full-time"
               },
-              "specialities": [
+              "specialties": [
                 {
                   "id": "2",
                   "name": "Backend"
@@ -128,7 +128,7 @@
                 "id": "1",
                 "name": "full-time"
               },
-              "specialities": [
+              "specialties": [
                 {
                   "id": "2",
                   "name": "Backend"

--- a/app/graphql/types/freak_type.rb
+++ b/app/graphql/types/freak_type.rb
@@ -14,7 +14,7 @@ module Types
     field :role, RoleType, null: false
     field :level, LevelType, null: false
     field :norm, NormType, null: false
-    field :specialities, [SpecialityType], null: false
+    field :specialties, [SpecialtyType], null: false
     field :technologies, [TechnologyType], null: false
   end
 end

--- a/app/graphql/types/specialty_type.rb
+++ b/app/graphql/types/specialty_type.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Types
-  class SpecialityType < Types::BaseObject
+  class SpecialtyType < Types::BaseObject
     field :id, GraphQL::Types::ID, null: false
     field :name, String, null: false
   end

--- a/app/models/freak.rb
+++ b/app/models/freak.rb
@@ -55,7 +55,7 @@ class Freak < ApplicationRecord
     }
   end
 
-  def specialities
+  def specialties
     [
       {
         id: '2',

--- a/spec/fixtures/requests/queries/freaks.graphql
+++ b/spec/fixtures/requests/queries/freaks.graphql
@@ -51,7 +51,7 @@ query Freaks($last: Int, $before: String) {
                     id
                     name
                 }
-                specialities {
+                specialties {
                     id
                     name
                 }

--- a/spec/fixtures/responses/queries/freaks/freaks.json
+++ b/spec/fixtures/responses/queries/freaks/freaks.json
@@ -71,7 +71,7 @@
                 "id": "1",
                 "name": "full-time"
               },
-              "specialities": [
+              "specialties": [
                 {
                   "id": "2",
                   "name": "Backend"
@@ -150,7 +150,7 @@
                 "id": "1",
                 "name": "full-time"
               },
-              "specialities": [
+              "specialties": [
                 {
                   "id": "2",
                   "name": "Backend"

--- a/spec/fixtures/responses/queries/freaks/freaks_pagination.json
+++ b/spec/fixtures/responses/queries/freaks/freaks_pagination.json
@@ -71,7 +71,7 @@
                 "id": "1",
                 "name": "full-time"
               },
-              "specialities": [
+              "specialties": [
                 {
                   "id": "2",
                   "name": "Backend"


### PR DESCRIPTION
## Description
Rename _specialities_ field with _specialties_ and _Speciality_ with _Specialty_.
Specialty is the word used in American English, while speciality is used in British English. Because we are speaking American English, we'll use Specialty form of this noun.

## Related
<!-- Edit the ticket below to match the correct one; you can specify here other related items, such as PRs -->

## Steps to Test or Reproduce
<!-- How can the reviewer test or reproduce the feature/improvement/bug implemented here? -->
Go to Insomnia and run the following query to get a list of freaks.
```GraphQl
query Freaks($last: Int, $before: String) {
    freaks(last: $last, before: $before) {
        pageInfo {
            endCursor
            startCursor
            hasPreviousPage
            hasNextPage
        }
        edges {
            node {
                name
                firstName
                lastName
                description
                email
                photo {
                    id
                    uri
                }
                skills {
                    id
                    name
                }
                projects {
                    id
                    name
                    description
                    logoUrl {
                        id
                        uri
                    }
                    freaks {
                        id
                        firstName
                    }
                    technologies {
                        id
                        name
                        description
                    }
                }
                role {
                    id
                    name
                }
                level {
                    id
                    name
                }
                norm {
                    id
                    name
                }
                specialties {
                    id
                    name
                }
                technologies {
                    id
                    name
                }
            }
        }
    }
}
__
```
You can see that the _specialities_ field has become now _specialties_.
