### PR TITLE
[141] Add new technologies query node

### DIFF
--- a/app/graphql/resolvers/technologies_resolver.rb
+++ b/app/graphql/resolvers/technologies_resolver.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'json'
+
+module Resolvers
+  class TechnologiesResolver < Resolvers::Base
+    type [Types::TechnologyType], null: false
+
+    # :reek:UtilityFunction
+    def resolve
+      Technology.all
+    end
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -7,5 +7,6 @@ module Types
     include GraphQL::Types::Relay::HasNodesField
 
     field :freaks, resolver: Resolvers::FreaksResolver
+    field :technologies, resolver: Resolvers::TechnologiesResolver
   end
 end

--- a/spec/controllers/graphql/queries/technologies_spec.rb
+++ b/spec/controllers/graphql/queries/technologies_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module Graphql
+  RSpec.describe GraphqlController, type: :controller do
+    subject { post :execute, params: params, as: :json }
+
+    let(:params) do
+      {
+        query: File.read('spec/fixtures/requests/queries/technologies.graphql')
+      }
+    end
+
+    before do
+      create(:technology, :ruby)
+      create(:technology, :java)
+    end
+
+    it { is_expected.to match_response_for(query: :technologies, sample: :technologies) }
+  end
+end

--- a/spec/fixtures/requests/queries/technologies.graphql
+++ b/spec/fixtures/requests/queries/technologies.graphql
@@ -1,0 +1,6 @@
+query {
+    technologies{
+        name
+        description
+    }
+}

--- a/spec/fixtures/responses/queries/technologies/technologies.json
+++ b/spec/fixtures/responses/queries/technologies/technologies.json
@@ -1,0 +1,17 @@
+{
+  "status": 200,
+  "body": {
+    "data": {
+      "technologies": [
+        {
+          "name": "Ruby",
+          "description": "A popular back-end language"
+        },
+        {
+          "name": "Java",
+          "description": "One of the most popular programming languages"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Description
Create a new node to list all technologies

## Related
<!-- Edit the ticket below to match the correct one; you can specify here other related items, such as PRs -->
[[141] New "technologies" query node](https://trello.com/c/yCuXaBiZ/141-new-technologies-query-node)

## Steps to Test or Reproduce
Go to Insomnia and execute this query:
```GraphQl
query {
    technologies{
        name
        description
    }
}
```
It should return a list of all technologies from database, without pagination.
NOTE: data from `technologies` table will be automatically added in database with help of _database seeds_.
