### PR TITLE
[] Remove camelCase naming convention

### DIFF
--- a/app/graphql/types/project_type.rb
+++ b/app/graphql/types/project_type.rb
@@ -5,7 +5,7 @@ module Types
     field :id, GraphQL::Types::ID, null: false
     field :name, String, null: false
     field :description, String, null: false
-    field :logoUrl, PhotoType, null: false
+    field :logo_url, PhotoType, null: false
     field :freaks, [FreakType], null: false
     field :technologies, [TechnologyType], null: false
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Project < ApplicationRecord
-  has_one :logoUrl, as: :imageable, dependent: :destroy, class_name: 'Photo'
+  has_one :logo_url, as: :imageable, dependent: :destroy, class_name: 'Photo'
 
   has_many :freaks_projects, dependent: nil, class_name: 'FreakProject'
   has_many :freaks, through: :freaks_projects, dependent: nil

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -27,12 +27,13 @@ class Seeds
         Role.find_or_create_by!(name: roles)
       end
 
+      rails.logo_url = Photo.find_or_create_by!(uri: 'www.url.ro', imageable: rails)
+      rails.logo_url = Photo.find_or_create_by(uri: 'www.url.ro', imageable: rails)
+
       level=Level.find_or_create_by(name: "Intern")
       %w[Intern Novice Advanced Competent Proficient Expert Master].each do |level_name|
         Level.find_or_create_by(name: level_name)
       end
-
-      rails.logoUrl = Photo.find_or_create_by(uri: 'www.url.ro', imageable: rails)
 
       Freak.find_or_create_by(
         first_name: 'John',

--- a/spec/factories/project.rb
+++ b/spec/factories/project.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     description { 'An American premium cable and satellite TV network.' }
 
     after(:build) do |project|
-      project.logoUrl = create(:photo, imageable: project)
+      project.logo_url = create(:photo, imageable: project)
       project.technologies = create_list(:technology, 1, :ruby)
       project.freaks = create_list(:freak, 1)
     end


### PR DESCRIPTION
## Description
Rename `logoUrl` field with `logo_url`. In Ruby, we use `snake_case`, not `camelCase`.

## Related
<!-- Edit the ticket below to match the correct one; you can specify here other related items, such as PRs -->

## Steps to Test or Reproduce
<!-- How can the reviewer test or reproduce the feature/improvement/bug implemented here? -->
