### PR TITLE
[209] New levels query node

### DIFF
--- a/app/graphql/resolvers/levels_resolver.rb
+++ b/app/graphql/resolvers/levels_resolver.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Resolvers
+  class LevelsResolver < Resolvers::Base
+    type [Types::LevelType], null: false
+
+    def resolve
+      Level.all
+    end
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -12,5 +12,6 @@ module Types
     field :technologies, resolver: Resolvers::TechnologiesResolver
     field :projects, resolver: Resolvers::ProjectsResolver
     field :roles, resolver: Resolvers::RolesResolver
+    field :levels, resolver: Resolvers::LevelsResolver
   end
 end

--- a/spec/controllers/graphql/queries/levels_spec.rb
+++ b/spec/controllers/graphql/queries/levels_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module Graphql
+  RSpec.describe GraphqlController, type: :controller do
+    subject(:query_freaks) { post :execute, params: params, as: :json }
+
+    let(:params) do
+      {
+        query: File.read('spec/fixtures/requests/queries/levels.graphql')
+      }
+    end
+
+    before do
+      create(:level, :beginner)
+    end
+
+    it { is_expected.to match_response_for(query: :levels, sample: :level) }
+  end
+end

--- a/spec/factories/level.rb
+++ b/spec/factories/level.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :level, class: 'Level' do
     name { 'Advanced' }
-    trait :Beginner do
+    trait :beginner do
       name { 'Beginner' }
     end
   end

--- a/spec/fixtures/requests/queries/levels.graphql
+++ b/spec/fixtures/requests/queries/levels.graphql
@@ -1,0 +1,5 @@
+query{
+    levels {
+        name
+    }
+}

--- a/spec/fixtures/responses/queries/levels/level.json
+++ b/spec/fixtures/responses/queries/levels/level.json
@@ -1,0 +1,12 @@
+{
+  "status": 200,
+  "body": {
+    "data": {
+      "levels": [
+        {
+          "name": "Beginner"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Description
Add a new query node to get all levels from database.

## Related
<!-- Edit the ticket below to match the correct one; you can specify here other related items, such as PRs -->
[[209] New "levels" query node](https://trello.com/c/KdL8vuPE/209-new-levels-query-node)

## Steps to Test or Reproduce
Go to Insomnia and run this query:
```GraphQl
query{
    levels {
        name
    }
}
```
You should get a list with all levels from database.
