### PR TITLE
[146] Create a new freakDeactivate mutation node

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '3.0.1'
 
+gem 'discard', '~> 1.2'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails', branch: 'main'
 gem 'rails', '~> 6.1.4'
 # Use Puma as the app server

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,8 @@ GEM
       database_cleaner-core (~> 2.0.0)
     database_cleaner-core (2.0.1)
     diff-lcs (1.4.4)
+    discard (1.2.0)
+      activerecord (>= 4.2, < 7)
     dotenv (2.7.6)
     dotenv-rails (2.7.6)
       dotenv (= 2.7.6)
@@ -311,6 +313,7 @@ DEPENDENCIES
   byebug
   capybara (>= 3.26)
   database_cleaner-active_record
+  discard (~> 1.2)
   dotenv-rails (~> 2.7.6)
   factory_bot_rails (~> 6.2.0)
   faker

--- a/app/graphql/resolvers/freak_deactivate_resolver.rb
+++ b/app/graphql/resolvers/freak_deactivate_resolver.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'discard'
 module Resolvers
   class FreakDeactivateResolver < Resolvers::Base
     argument :id, GraphQL::Types::ID, required: true,

--- a/app/graphql/resolvers/freak_deactivate_resolver.rb
+++ b/app/graphql/resolvers/freak_deactivate_resolver.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
+
 require 'discard'
 module Resolvers
   class FreakDeactivateResolver < Resolvers::Base
     argument :id, GraphQL::Types::ID, required: true,
-             validates: { in_db: { type: Freak } }
+                                      validates: { in_db: { type: Freak } }
 
     type Types::FreakType, null: true
 
     def resolve(id:)
-      freak= Freak.find(id)
+      freak = Freak.find(id)
       freak.discard
       freak
     end
   end
 end
-

--- a/app/graphql/resolvers/freak_deactivate_resolver.rb
+++ b/app/graphql/resolvers/freak_deactivate_resolver.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+require 'discard'
+module Resolvers
+  class FreakDeactivateResolver < Resolvers::Base
+    argument :id, GraphQL::Types::ID, required: true
+
+    type GraphQL::Types::ID, null: true
+
+    def resolve(id:)
+      Freak.find(id).discard
+    end
+  end
+end
+

--- a/app/graphql/resolvers/freak_deactivate_resolver.rb
+++ b/app/graphql/resolvers/freak_deactivate_resolver.rb
@@ -2,12 +2,15 @@
 require 'discard'
 module Resolvers
   class FreakDeactivateResolver < Resolvers::Base
-    argument :id, GraphQL::Types::ID, required: true
+    argument :id, GraphQL::Types::ID, required: true,
+             validates: { in_db: { type: Freak } }
 
-    type GraphQL::Types::ID, null: true
+    type Types::FreakType, null: true
 
     def resolve(id:)
-      Freak.find(id).discard
+      freak= Freak.find(id)
+      freak.discard
+      freak
     end
   end
 end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -5,5 +5,6 @@ module Types
     field :freak_create, resolver: Resolvers::FreakCreateResolver
     field :photo_create, resolver: Resolvers::PhotoCreateResolver
     field :freak_update, resolver: Resolvers::FreakUpdateResolver
+    field :freak_deactivate, resolver: Resolvers::FreakDeactivateResolver
   end
 end

--- a/app/models/freak.rb
+++ b/app/models/freak.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class Freak < ApplicationRecord
+  include Discard::Model
+  # default_scope -> { kept }
+
   scope :on_all_projects, lambda { |ids|
     if ids.present?
       matching_freak_ids = group(:id)

--- a/app/models/freak.rb
+++ b/app/models/freak.rb
@@ -2,7 +2,7 @@
 
 class Freak < ApplicationRecord
   include Discard::Model
-  # default_scope -> { kept }
+  default_scope -> { kept }
 
   scope :on_all_projects, lambda { |ids|
     if ids.present?

--- a/db/migrate/20210908082709_add_discarded_to_freaks.rb
+++ b/db/migrate/20210908082709_add_discarded_to_freaks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddDiscardedToFreaks < ActiveRecord::Migration[6.1]
   def change
     add_column :freaks, :discarded_at, :datetime

--- a/db/migrate/20210908082709_add_discarded_to_freaks.rb
+++ b/db/migrate/20210908082709_add_discarded_to_freaks.rb
@@ -1,0 +1,6 @@
+class AddDiscardedToFreaks < ActiveRecord::Migration[6.1]
+  def change
+    add_column :freaks, :discarded_at, :datetime
+    add_index :freaks, :discarded_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_23_122623) do
+ActiveRecord::Schema.define(version: 2021_09_08_082709) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,6 +25,8 @@ ActiveRecord::Schema.define(version: 2021_08_23_122623) do
     t.string "last_name"
     t.string "email"
     t.bigint "level_id"
+    t.datetime "discarded_at"
+    t.index ["discarded_at"], name: "index_freaks_on_discarded_at"
   end
 
   create_table "freaks_projects", force: :cascade do |t|

--- a/spec/controllers/graphql/mutations/freak_deactivate_spec.rb
+++ b/spec/controllers/graphql/mutations/freak_deactivate_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module Graphql
+  RSpec.describe GraphqlController, type: :controller do
+    subject { post :execute, params: params, as: :json }
+
+    let(:freak_id) { create(:freak).id }
+    let(:params) do
+      {
+        query: File.read('spec/fixtures/requests/mutations/freak_deactivate.graphql'),
+        variables: {
+          id: freak_id
+        }
+      }
+    end
+
+    context 'when freak is deactivate' do
+      it { is_expected.to match_response_for(mutation: :freak_deactivate, sample: :freak_deactivate) }
+    end
+  end
+end

--- a/spec/fixtures/requests/mutations/freak_deactivate.graphql
+++ b/spec/fixtures/requests/mutations/freak_deactivate.graphql
@@ -1,0 +1,5 @@
+mutation($id: ID!) {
+    freakDeactivate(id: $id) {
+        id
+    }
+}

--- a/spec/fixtures/responses/mutations/freak_deactivate/freak_deactivate.json
+++ b/spec/fixtures/responses/mutations/freak_deactivate/freak_deactivate.json
@@ -1,0 +1,10 @@
+{
+  "status": 200,
+  "body": {
+    "data": {
+      "freakDeactivate": {
+        "id": "2"
+      }
+    }
+  }
+}

--- a/spec/fixtures/responses/mutations/freak_update/freak_update.json
+++ b/spec/fixtures/responses/mutations/freak_update/freak_update.json
@@ -3,7 +3,7 @@
   "body": {
     "data": {
       "freakUpdate": {
-        "id": "2",
+        "id": "3",
         "firstName": "Dorel",
         "lastName": "zidarul",
         "description": "priceput la tot prin casa",


### PR DESCRIPTION
## Description
Create a new mutation to deactivate a freak. We use soft delete, so the freak will not be completely removed from database.

## Related
<!-- Edit the ticket below to match the correct one; you can specify here other related items, such as PRs -->
[[146] New "freakDeactivate" mutation node](https://trello.com/c/ALnfBoDJ/146-new-freakdeactivate-mutation-node)

## Steps to Test or Reproduce
Go to Insomnia and run this mutation:
```GraphQl
mutation {
  freakDeactivate(id: "1") {
    id
  }
}
```
After running this mutation, go to `freaks` table in database. The freak with id should have the date and time when it was discarded at `discard_at` column. To make sure this feature is working, run below query to get all freaks and see that deactivated freak won't be in the list.
```GraphQl
query Freaks($filter: FreakFilter, $last: Int, $before: String) {
  freaks(filter: $filter, last: $last, before: $before) {
    edges {
      node {
        id
      }
    }
  }
}
```
If you want to deactivate a freak that don't exist (or is already deactivated), you will get an suitable error message.

